### PR TITLE
helm support

### DIFF
--- a/hiwin.el
+++ b/hiwin.el
@@ -162,7 +162,8 @@
       (setq hw-win-lst (cdr hw-win-lst))
       ;; ミニバッファとアクティブ ウィンドウ以外を処理
       (unless (or (eq hw-tgt-win (minibuffer-window))
-                  (eq hw-tgt-win hiwin-active-window))
+                  (eq hw-tgt-win hiwin-active-window)
+                  (string-match "^\\*helm" (buffer-name (window-buffer hw-tgt-win))))
           (progn
             ;; 処理対象ウィンドウを選択
             (select-window hw-tgt-win)

--- a/hiwin.el
+++ b/hiwin.el
@@ -77,6 +77,10 @@
 ;; 非アクティブウィンドウのオーバーレイ．
 (defvar hiwin-overlays nil)
 
+;; 常時アクティブにするバッファ名の正規表現
+(defvar hiwin-always-active-buffer-name-regexp "^\\*helm")
+
+
 ;; 非アクティブウィンドウのオーバーレイ描画用のフェイス．
 (defvar hiwin-face nil)
 (make-face 'hiwin-face)
@@ -163,7 +167,8 @@
       ;; ミニバッファとアクティブ ウィンドウ以外を処理
       (unless (or (eq hw-tgt-win (minibuffer-window))
                   (eq hw-tgt-win hiwin-active-window)
-                  (string-match "^\\*helm" (buffer-name (window-buffer hw-tgt-win))))
+                  (string-match hiwin-always-active-buffer-name-regexp
+                                (buffer-name (window-buffer hw-tgt-win))))
           (progn
             ;; 処理対象ウィンドウを選択
             (select-window hw-tgt-win)


### PR DESCRIPTION
えー、日本語で失礼します。

helmのウインドウを開いたときにアイテムの選択ウィンドウが非アクティブ化してしまうので、それを直してみました。

helmが開いてるときにアクティブなウィンドウはミニバッファなので当然といえば当然の動きなのですが。

これを実現するのにバッファ名を正規表現で比較するようにしたので、その正規表現を変数化して一般化しました。それが`hiwin-always-active-buffer-name-regexp `です。あまりちゃんとコードを読まずに適当にいじってうまく動いているように見えるのでpull-requestを出しましたが、こんなのでよいでしょうか。