### PR TITLE
Fix hiwin selecting another window unexpectedly

### DIFF
--- a/hiwin.el
+++ b/hiwin.el
@@ -179,9 +179,9 @@
             )
           ))
     ;; 元のアクティブウィンドウを選択
-    (if  hiwin-server-flag
-      (setq hiwin-server-flag 'nil)
-      (select-window hiwin-active-window))
+    (when hiwin-server-flag
+      (setq hiwin-server-flag 'nil))
+    (select-window hiwin-active-window)
     ))
 
 ;;;###autoload


### PR DESCRIPTION
This fixes #3 for me, in some limited testing.  There's likely a better fix (what is the purpose of hiwin-server-flag anyway?), but this works for me.