### PR TITLE
Add a proper param for each (select-window)

### DIFF
--- a/hiwin.el
+++ b/hiwin.el
@@ -172,7 +172,7 @@
                                 (buffer-name (window-buffer hw-tgt-win))))
           (progn
             ;; 処理対象ウィンドウを選択
-            (select-window hw-tgt-win)
+            (select-window hw-tgt-win t)
             ;; 処理対象ウィンドウにオーバーレイを設定
             (move-overlay (nth hw-cnt hiwin-overlays)
                           (point-min) (point-max) (current-buffer))
@@ -184,7 +184,7 @@
     ;; 元のアクティブウィンドウを選択
     (when hiwin-server-flag
       (setq hiwin-server-flag 'nil))
-    (select-window hiwin-active-window)
+    (select-window hiwin-active-window t)
     ))
 
 ;;;###autoload


### PR DESCRIPTION
I found a problem about this package, when I use other packages (see: https://github.com/cyrus-and/zoom/issues/13#event-1333894802).

It should set `select-window` NORECORD option `t`, because this package just changes the background-color of non-selected windows, so it should tell Emacs that the switching itself does not cause any visible layout changes.

If `NORECORD` option is `nil`, it will trigger `buffer-list-update-hook` (see: `M-x describe-function select-window`), and unnecessarilly call other functions related to this hook. (ex. [zoom](https://github.com/cyrus-and/zoom))
