### PR TITLE
cherry-pick patches from https://github.com/fenril058/hiwin-mode

### DIFF
--- a/hiwin.el
+++ b/hiwin.el
@@ -193,7 +193,7 @@ Face for inactive window.")
           ;; これをしないとポイントが遠くに飛ばされてしまう.
           (when (and (eq (point) (point-max))
                      (> (point-max) 1))
-            (insert " ")
+            (unless buffer-read-only (insert " "))
             (backward-char 1)
             )
           ;; 処理対象ウィンドウにオーバーレイを設定

--- a/hiwin.el
+++ b/hiwin.el
@@ -188,12 +188,12 @@ Face for inactive window.")
         (save-selected-window
           ;; 処理対象ウィンドウを選択
           (select-window hw-tgt-win)
-          ;; バッファ末尾の場合，半角スペースを一文字挿入し, ポイント
-          ;; を一文字戻す.  overlayで末尾に改行をたくさん挿入するとき,
-          ;; これをしないとポイントが遠くに飛ばされてしまう.
+          ;; バッファ末尾の場合， ポイントを一文字戻す.  overlayの
+          ;; after-stringで末尾に改行をたくさん挿入するとき, こうしな
+          ;; いとポイントが遠くに飛ばされてしまう.
           (when (and (eq (point) (point-max))
                      (> (point-max) 1))
-            (unless buffer-read-only (insert " "))
+            ;; (unless buffer-read-only (insert " "))
             (backward-char 1)
             )
           ;; 処理対象ウィンドウにオーバーレイを設定


### PR DESCRIPTION
Even though https://github.com/fenril058/hiwin-mode has newer patches, MELPA treats this repo as the source. I could make a PR against MELPA to treat fenril's repo as the new source, but for some reason fenril's repo does not have any history even though it's based off of this repo. So I'm trying to do here what should have been done in the first place.

For me personally I would like to make use of the `hiwin-ignore-buffer-name-regexp` feature.